### PR TITLE
build: bump android-compile-sdk 35 -> 36

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ kover                        = "0.9.8"
 android-lint                 = "31.11.2"
 
 # Android platform
-android-compile-sdk          = "35"
+android-compile-sdk          = "36"
 android-target-sdk           = "35"
 android-min-sdk              = "26"
 


### PR DESCRIPTION
## Summary
- Bumps `android-compile-sdk` from 35 to 36 in `gradle/libs.versions.toml`.
- Required by `okhttp-android` 5.4.0 (see PR #25), which raises its `minCompileSdk` to 36. Several AndroidX AARs are on the same trajectory.

## Why this is low-risk
- `compileSdk` = the highest Android API version the code can *reference*. Bumping it does not force any behaviour change.
- `targetSdk` stays at 35 — no runtime-behaviour opt-in for Android 16.
- `minSdk` stays at 26 — same device compatibility.
- Local: `:app:assembleDebug`, `testDebugUnitTest`, `:app:lintDebug` all green with SDK 36.

## Test plan
- [ ] All CI jobs green (unit tests, assemble debug + lint, emulator 26 + 33, R8 release, reproducible build, OWASP).
- [ ] After merge, rebase #25 (okhttp 5.4.0) and re-verify it goes green.