### PR TITLE
ci:dependencyCheck: also trigger OWASP on suppression-file edits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -267,7 +267,7 @@ jobs:
     if: >-
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' && contains(github.event.commits.*.modified, 'gradle/libs.versions.toml')) ||
+      (github.event_name == 'push' && (contains(github.event.commits.*.modified, 'gradle/libs.versions.toml') || contains(github.event.commits.*.modified, 'config/dependency-check-suppressions.xml'))) ||
       (github.event_name == 'pull_request')
     runs-on: ubuntu-latest
     timeout-minutes: 60


### PR DESCRIPTION
## Summary
- Extends the OWASP job's `push` filter in `.github/workflows/build.yml` to include `config/dependency-check-suppressions.xml`.
- Previously only `gradle/libs.versions.toml` changes re-fired the scan on master, so suppression edits shipped without verifying CI.
- Verified in commit `0a92309`: the CVE-2026-53914 suppression landed and master's OWASP job did not auto-run — a manual `workflow_dispatch` was needed.

## Test plan
- [ ] `pull_request` CI green (this PR touches no dep, so OWASP will run because of the `pull_request` branch of the filter).
- [ ] After merge to master, next suppression-file edit auto-runs OWASP on master (structural check; no code path to test now).